### PR TITLE
Do not take ownership of clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
     let pins = arduino_hal::pins!(dp);
 
+    let mut delay = Delay::new();
+
     let mut serial = arduino_hal::default_serial!(dp, pins, 115200);
     let (spi, cs) = Spi::new(
         dp.SPI,
@@ -45,13 +47,16 @@ fn main() -> ! {
             mode: embedded_hal::spi::MODE_0,
         },
     );
-    let mut can = MCP2515::new(spi, cs, Delay::new());
-    can.init(mcp2515::Settings {
+    let mut can = MCP2515::new(spi, cs);
+    can.init(
+      &mut delay,
+      mcp2515::Settings {
         mode: OpMode::Loopback,       // Loopback for testing and example
         can_speed: CanSpeed::Kbps100, // Many options supported.
         mcp_speed: McpSpeed::MHz8,    // Currently 16MHz and 8MHz chips are supported.
         clkout_en: false,
-    })
+      }
+    )
     .unwrap();
 
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,11 @@ where
     ///
     /// * `delay` - Delay interface from downstream HAL.
     /// * `settings` - Settings for MCP2515. See [`Settings`].
-    pub fn init(&mut self, delay: &mut impl DelayMs<u8>, settings: Settings) -> Result<(), SPIE, CSE> {
+    pub fn init(
+        &mut self,
+        delay: &mut impl DelayMs<u8>,
+        settings: Settings,
+    ) -> Result<(), SPIE, CSE> {
         self.cs.set_high().map_err(Error::Hal)?;
         self.reset(delay)?;
 
@@ -488,8 +492,9 @@ where
     /// Resets the MCP2515.
     pub fn reset(&mut self, delay: &mut impl DelayMs<u8>) -> Result<(), SPIE, CSE> {
         self.transfer(&mut [Instruction::Reset as u8])?;
-        delay.delay_ms(5); // Sleep for 5ms after reset - if the device is in sleep mode it won't respond
-                                // immediately.
+        // Sleep for 5ms after reset - if the device is in sleep mode it won't respond immediately
+        delay.delay_ms(5);
+
         Ok(())
     }
 


### PR DESCRIPTION
Many implementations of `embedded_hal::blocking::delay::DelayMs` take ownership of hardware clocks. It is therefore not desirable to give the `MCP2515` struct ownership of a delay implementation, since that would mean giving away ownership of the clock as well.

I have tested the changes on the RP2040.

fixes #1 